### PR TITLE
Wrap the OutputPathBaseDir argument in double quotes.

### DIFF
--- a/build/scripts/Building.fsx
+++ b/build/scripts/Building.fsx
@@ -41,8 +41,8 @@ type Build() =
               "CurrentAssemblyVersion", (Versioning.CurrentAssemblyVersion.ToString());
               "CurrentAssemblyFileVersion", (Versioning.CurrentAssemblyFileVersion.ToString());
               "DoSourceLink", sourceLink;
-              "OutputPathBaseDir", Path.GetFullPath Paths.BuildOutput;            
-          ] 
+              "OutputPathBaseDir", "\"" + (Path.GetFullPath Paths.BuildOutput) + "\"";
+          ]
           |> List.map (fun (p,v) -> sprintf "%s=%s" p v)
           |> String.concat ";"
           |> sprintf "/property:%s"


### PR DESCRIPTION
Fixes an issue in Building.fsx, compileCore(), where if the project path contains spaces...

e.g. `C:\Users\My Name\Code\AsciiDocNet`

...the build fails.